### PR TITLE
Configure `hawkeye` to update license headers

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -1,4 +1,4 @@
-amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.0.1#/PklCI.pkl"
+amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.2.0#/PklCI.pkl"
 
 prb {
   jobs {

--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -1,14 +1,16 @@
 amends "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.circleci@1.2.0#/PklCI.pkl"
 
+local testJobs = jobs.keys.filter((it) -> it.startsWith("test"))
+
 prb {
   jobs {
-    "test"
+    ...testJobs
   }
 }
 
 main {
   jobs {
-    "test"
+    ...testJobs
   }
 }
 
@@ -29,6 +31,19 @@ jobs {
           chmod +x pkl.bin
           PKL_EXEC=$(pwd)/pkl.bin swift test
           """
+      }
+    }
+  }
+  ["test-license-headers"] {
+    docker {
+      new {
+        image = "ghcr.io/korandoru/hawkeye"
+      }
+    }
+    steps {
+      "checkout"
+      new RunStep {
+        command = "/bin/hawkeye check --fail-if-unknown"
       }
     }
   }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ workflows:
     - test:
         requires:
         - hold
-        - pr-approval/authenticate
     when:
       matches:
         value: << pipeline.git.branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,13 @@ jobs:
           PKL_EXEC=$(pwd)/pkl.bin swift test
     docker:
     - image: swift:5.9
+  test-license-headers:
+    steps:
+    - checkout
+    - run:
+        command: /bin/hawkeye check --fail-if-unknown
+    docker:
+    - image: ghcr.io/korandoru/hawkeye
 workflows:
   prb:
     jobs:
@@ -25,6 +32,9 @@ workflows:
     - test:
         requires:
         - hold
+    - test-license-headers:
+        requires:
+        - hold
     when:
       matches:
         value: << pipeline.git.branch >>
@@ -32,6 +42,7 @@ workflows:
   main:
     jobs:
     - test
+    - test-license-headers
     when:
       equal:
       - main

--- a/.swiftformat
+++ b/.swiftformat
@@ -13,7 +13,6 @@
 --guardelse same-line
 --nevertrailing filter
 --extensionacl on-declarations
---header "// ===----------------------------------------------------------------------===//\n// Copyright © {year} Apple Inc. and the Pkl project authors. All rights reserved.\n//\n// Licensed under the Apache License, Version 2.0 (the \"License\");\n// you may not use this file except in compliance with the License.\n// You may obtain a copy of the License at\n//\n//	https://www.apache.org/licenses/LICENSE-2.0\n//\n// Unless required by applicable law or agreed to in writing, software\n// distributed under the License is distributed on an \"AS IS\" BASIS,\n// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n// See the License for the specific language governing permissions and\n// limitations under the License.\n// ===----------------------------------------------------------------------===//"
 
 # rules
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,20 @@
 // swift-tools-version:5.9
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
 import PackageDescription
 
 let package = Package(

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,18 +1,18 @@
-// ===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// ===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 import Gen
 import PklSwift

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -1,18 +1,18 @@
-// ===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// ===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 import Logging
 import Vapor

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,18 +1,18 @@
-// ===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// ===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 import Vapor
 

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -1,18 +1,18 @@
-// ===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// ===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 @testable import App
 import XCTVapor

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -1,0 +1,27 @@
+additionalHeaders = ["scripts/custom-header-style.toml"]
+
+headerPath = "scripts/license-header.txt"
+
+includes = [
+    "*.pkl",
+    "*.sh",
+    "*.swift",
+    "Package.swift",
+    "PklProject",
+]
+
+excludes = [
+    ".index-build",
+    "Sources/Gen",
+    "build",
+]
+
+[git]
+attrs = 'enable'
+ignore = 'enable'
+
+[properties]
+copyrightOwner = "Apple Inc. and the Pkl project authors"
+
+[mapping.SWIFT_STYLE]
+extensions = ["swift"]

--- a/pkl/Config.pkl
+++ b/pkl/Config.pkl
@@ -1,18 +1,19 @@
-// ===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// ===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
 module Config
 
 /// The address the server will accept connections on

--- a/pkl/dev/config.pkl
+++ b/pkl/dev/config.pkl
@@ -1,18 +1,19 @@
-// ===----------------------------------------------------------------------===//
-// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//===----------------------------------------------------------------------===//
+// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// ===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+
 amends "../Config.pkl"
 
 hostname = "localhost"

--- a/scripts/custom-header-style.toml
+++ b/scripts/custom-header-style.toml
@@ -1,0 +1,11 @@
+[SWIFT_STYLE]
+firstLine = '//===----------------------------------------------------------------------===//'
+endLine = "//===----------------------------------------------------------------------===//\n"
+beforeEachLine = '// '
+afterEachLine = ''
+allowBlankLines = false
+multipleLines = true
+padLines = false
+firstLineDetectionPattern = '//\s?==='
+lastLineDetectionPattern = '//\s?==='
+skipLinePattern = '// swift-tools-version'

--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,0 +1,13 @@
+Copyright ©{{ " " }}{%- if attrs.git_file_modified_year != attrs.git_file_created_year -%}{{ attrs.git_file_created_year }}-{{ attrs.git_file_modified_year }}{%- else -%}{{ attrs.git_file_created_year }}{%- endif -%}{{ " " }}{{ props["copyrightOwner"] }}. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Adds configuration to format/check license headers with `hawkeye`.

Additionally, ran the formatter on license headers that needed to be updated.